### PR TITLE
Abstract out manifests more

### DIFF
--- a/ManifestData.cs
+++ b/ManifestData.cs
@@ -9,14 +9,12 @@ namespace TalosDownpatcher {
 
     public readonly int numFiles; // @Cleanup: Unused, but definitely should be (at least for validation).
     public readonly long size;
-    public readonly Package package;
-    public SteamManifest(int appId, int depotId, long manifestId, int numFiles, long size, Package package) {
+    public SteamManifest(int appId, int depotId, long manifestId, int numFiles, long size) {
       this.appId = appId;
       this.depotId = depotId;
       this.manifestId = manifestId;
       this.numFiles = numFiles;
       this.size = size;
-      this.package = package;
     }
   }
 
@@ -31,325 +29,262 @@ namespace TalosDownpatcher {
       243520, 226087, 224995, 224531, 223249, 222477, 221394, 220996,
       220675, 220625, 220480
     };
-    // Possibly replace with:
-    // public static List<int> allVersions { get { return data.Keys.ToList(); } }
 
-    public static long GetDownloadSize(int version, Package package = Package.All) {
+    public static long GetDownloadSize(int version, Package package) {
       long totalDownloadSize = 0;
-      foreach (var manifest in GetManifestsForVersion(version, package)) {
+      foreach (var manifest in GetAllManifestsForVersion(version)[package]) {
         totalDownloadSize += manifest.size;
       }
       return totalDownloadSize;
     }
 
-    public static IEnumerable<SteamManifest> GetManifestsForVersion(int version, Package package = Package.All) {
-      return data[version].Where(m => package == Package.All || package == m.package);
+    public static Dictionary<Package, List<SteamManifest>> GetAllManifestsForVersion(int version) {
+      return data[version];
     }
 
-    private static readonly Dictionary<int, List<SteamManifest>> data = InitData();
-    private static Dictionary<int, List<SteamManifest>> InitData() {
-      Dictionary<int, List<SteamManifest>> data = new Dictionary<int, List<SteamManifest>>();
+    private static readonly Dictionary<int, Dictionary<Package, List<SteamManifest>>> data = InitData();
+    private static Dictionary<int, Dictionary<Package, List<SteamManifest>>> InitData() {
+      Dictionary<int, Dictionary<Package, List<SteamManifest>>> data = new Dictionary<int, Dictionary<Package, List<SteamManifest>>>();
 
-      data[220480] = new List<SteamManifest>() {
-        new SteamManifest(257510, 257511, 4122334240058475272, 2, 48908496, Package.Main),
-        new SteamManifest(257510, 257515, 1348826399794024471, 32, 5055625401, Package.Main),
-        new SteamManifest(257510, 257516, 1237958166729860756, 6, 117245, Package.Main),
-        new SteamManifest(257510, 257519, 2322040020544521685, 1, 1739595, Package.Main),
-        new SteamManifest(257510, 322022, 2824340380872620137, 3, 172228256, Package.Prototype)
-      };
+      foreach (int version in allVersions) {
+        data[version] = new Dictionary<Package, List<SteamManifest>> {
+          [Package.Main] = new List<SteamManifest>(),
+          [Package.Gehenna] = new List<SteamManifest>(),
+          [Package.Prototype] = new List<SteamManifest>()
+        };
+      }
 
-      data[220625] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 8087374737096894864,  2,   48901328, Package.Main),
-        new SteamManifest(257510, 257515, 3617089317964903627, 32, 5217247608, Package.Main),
-        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
-        new SteamManifest(257510, 257519, 1272083368566319066,  1,    1789447, Package.Main),
-        new SteamManifest(257510, 322022, 8183524469048336858,  3,  206907989, Package.Prototype)
-      };
+      data[220480][Package.Main     ].Add(new SteamManifest(257510, 257511, 4122334240058475272,  2,   48908496));
+      data[220480][Package.Main     ].Add(new SteamManifest(257510, 257515, 1348826399794024471, 32, 5055625401));
+      data[220480][Package.Main     ].Add(new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245));
+      data[220480][Package.Main     ].Add(new SteamManifest(257510, 257519, 2322040020544521685,  1,    1739595));
+      data[220480][Package.Prototype].Add(new SteamManifest(257510, 322022, 2824340380872620137,  3,  172228256));
 
-      data[220675] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 2018192542376932921,  2,   48900816, Package.Main),
-        new SteamManifest(257510, 257515, 8986158524600611840, 32, 5217247413, Package.Main),
-        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
-        new SteamManifest(257510, 257519, 4554990112195176406,  1,    1789447, Package.Main),
-        new SteamManifest(257510, 322022, 4383443687812477256,  3,  206909511, Package.Prototype)
-      };
+      data[220625][Package.Main     ].Add(new SteamManifest(257510, 257511, 8087374737096894864,  2,   48901328));
+      data[220625][Package.Main     ].Add(new SteamManifest(257510, 257515, 3617089317964903627, 32, 5217247608));
+      data[220625][Package.Main     ].Add(new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245));
+      data[220625][Package.Main     ].Add(new SteamManifest(257510, 257519, 1272083368566319066,  1,    1789447));
+      data[220625][Package.Prototype].Add(new SteamManifest(257510, 322022, 8183524469048336858,  3,  206907989));
 
-      data[220996] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 3475103749484918333,  2,   48912080, Package.Main),
-        new SteamManifest(257510, 257515, 0415067456888111848, 27, 5439377389, Package.Main),
-        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
-        new SteamManifest(257510, 257519, 4906101680219337427,  1,    1858219, Package.Main),
-        new SteamManifest(257510, 322022, 7673940384630485679,  3,  211726262, Package.Prototype)
-      };
+      data[220675][Package.Main     ].Add(new SteamManifest(257510, 257511, 2018192542376932921,  2,   48900816));
+      data[220675][Package.Main     ].Add(new SteamManifest(257510, 257515, 8986158524600611840, 32, 5217247413));
+      data[220675][Package.Main     ].Add(new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245));
+      data[220675][Package.Main     ].Add(new SteamManifest(257510, 257519, 4554990112195176406,  1,    1789447));
+      data[220675][Package.Prototype].Add(new SteamManifest(257510, 322022, 4383443687812477256,  3,  206909511));
 
-      data[221394] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 1222567553988779631,  2,   48947920, Package.Main),
-        new SteamManifest(257510, 257515, 7204783264154690101, 27, 5842288583, Package.Main),
-        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
-        new SteamManifest(257510, 257519, 6019585236142413402,  1,    1981411, Package.Main),
-        new SteamManifest(257510, 322022, 6888774931510513164,  3,  218106434, Package.Prototype)
-      };
+      data[220996][Package.Main     ].Add(new SteamManifest(257510, 257511, 3475103749484918333,  2,   48912080));
+      data[220996][Package.Main     ].Add(new SteamManifest(257510, 257515, 0415067456888111848, 27, 5439377389));
+      data[220996][Package.Main     ].Add(new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245));
+      data[220996][Package.Main     ].Add(new SteamManifest(257510, 257519, 4906101680219337427,  1,    1858219));
+      data[220996][Package.Prototype].Add(new SteamManifest(257510, 322022, 7673940384630485679,  3,  211726262));
 
-      data[222477] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 0918811395787437543,  2,   49005264, Package.Main),
-        new SteamManifest(257510, 257515, 6267514976170907571, 27, 6094446568, Package.Main),
-        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
-        new SteamManifest(257510, 257519, 6671071736059004158,  1,    2059976, Package.Main),
-        new SteamManifest(257510, 322022, 8917339509592123029,  3,  225475410, Package.Prototype)
-      };
+      data[221394][Package.Main     ].Add(new SteamManifest(257510, 257511, 1222567553988779631,  2,   48947920));
+      data[221394][Package.Main     ].Add(new SteamManifest(257510, 257515, 7204783264154690101, 27, 5842288583));
+      data[221394][Package.Main     ].Add(new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245));
+      data[221394][Package.Main     ].Add(new SteamManifest(257510, 257519, 6019585236142413402,  1,    1981411));
+      data[221394][Package.Prototype].Add(new SteamManifest(257510, 322022, 6888774931510513164,  3,  218106434));
 
-      data[223249] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 4657839721186080333,  2,   49014480, Package.Main),
-        new SteamManifest(257510, 257515, 8304752583573271963, 27, 6094446741, Package.Main),
-        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
-        new SteamManifest(257510, 257519, 7835318215284690246,  1,    2059976, Package.Main),
-        new SteamManifest(257510, 322022, 3867407920981508845,  3,  225475676, Package.Prototype)
-      };
+      data[222477][Package.Main     ].Add(new SteamManifest(257510, 257511, 0918811395787437543,  2,   49005264));
+      data[222477][Package.Main     ].Add(new SteamManifest(257510, 257515, 6267514976170907571, 27, 6094446568));
+      data[222477][Package.Main     ].Add(new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245));
+      data[222477][Package.Main     ].Add(new SteamManifest(257510, 257519, 6671071736059004158,  1,    2059976));
+      data[222477][Package.Prototype].Add(new SteamManifest(257510, 322022, 8917339509592123029,  3,  225475410));
 
-      data[224531] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 3207947001105705384,  2,   37991120, Package.Main),
-        new SteamManifest(257510, 257515, 5798939509479840711, 28, 6281382910, Package.Main),
-        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
-        new SteamManifest(257510, 257519, 3565289474630779855,  1,    2117568, Package.Main),
-        new SteamManifest(257510, 322022, 7516537008051594086,  3,  243488546, Package.Prototype)
-      };
+      data[223249][Package.Main     ].Add(new SteamManifest(257510, 257511, 4657839721186080333,  2,   49014480));
+      data[223249][Package.Main     ].Add(new SteamManifest(257510, 257515, 8304752583573271963, 27, 6094446741));
+      data[223249][Package.Main     ].Add(new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245));
+      data[223249][Package.Main     ].Add(new SteamManifest(257510, 257519, 7835318215284690246,  1,    2059976));
+      data[223249][Package.Prototype].Add(new SteamManifest(257510, 322022, 3867407920981508845,  3,  225475676));
 
-      data[224995] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 9130874505093356390,  2,   38000336, Package.Main),
-        new SteamManifest(257510, 257515, 4840744566182207229, 28, 6281389510, Package.Main),
-        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
-        new SteamManifest(257510, 257519, 0660166059336687264,  1,    2117568, Package.Main),
-        new SteamManifest(257510, 322022, 6536174967355028889,  3,  243487857, Package.Prototype)
-      };
+      data[224531][Package.Main     ].Add(new SteamManifest(257510, 257511, 3207947001105705384,  2,   37991120));
+      data[224531][Package.Main     ].Add(new SteamManifest(257510, 257515, 5798939509479840711, 28, 6281382910));
+      data[224531][Package.Main     ].Add(new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245));
+      data[224531][Package.Main     ].Add(new SteamManifest(257510, 257519, 3565289474630779855,  1,    2117568));
+      data[224531][Package.Prototype].Add(new SteamManifest(257510, 322022, 7516537008051594086,  3,  243488546));
 
-      data[226087] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 2501832898327740448,  2,   38003408, Package.Main),
-        new SteamManifest(257510, 257515, 3826319505876650203, 29, 6282258753, Package.Main),
-        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
-        new SteamManifest(257510, 257519, 5081265059426016345,  1,    2117916, Package.Main),
-        new SteamManifest(257510, 322022, 7180495594989737482,  4,  275966134, Package.Prototype)
-      };
+      data[224995][Package.Main     ].Add(new SteamManifest(257510, 257511, 9130874505093356390,  2,   38000336));
+      data[224995][Package.Main     ].Add(new SteamManifest(257510, 257515, 4840744566182207229, 28, 6281389510));
+      data[224995][Package.Main     ].Add(new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245));
+      data[224995][Package.Main     ].Add(new SteamManifest(257510, 257519, 0660166059336687264,  1,    2117568));
+      data[224995][Package.Prototype].Add(new SteamManifest(257510, 322022, 6536174967355028889,  3,  243487857));
 
-      data[243520] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 0486897345253495735,  2,   37835472, Package.Main),
-        new SteamManifest(257510, 257515, 0762065295327824568, 29, 6870004878, Package.Main),
-        new SteamManifest(257510, 257516, 7901792711762181252,  7,     218389, Package.Main),
-        new SteamManifest(257510, 257519, 2020897382852338977,  1,    2312159, Package.Main),
-        new SteamManifest(257510, 358470, 3645040643832281528,  2,  704403859, Package.Gehenna),
-        new SteamManifest(257510, 322022, 1221230661228297401,  4,  291798721, Package.Prototype)
-      };
+      data[226087][Package.Main     ].Add(new SteamManifest(257510, 257511, 2501832898327740448,  2,   38003408));
+      data[226087][Package.Main     ].Add(new SteamManifest(257510, 257515, 3826319505876650203, 29, 6282258753));
+      data[226087][Package.Main     ].Add(new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245));
+      data[226087][Package.Main     ].Add(new SteamManifest(257510, 257519, 5081265059426016345,  1,    2117916));
+      data[226087][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 3953868769601855669,  2,  704404714));
+      data[226087][Package.Prototype].Add(new SteamManifest(257510, 322022, 7180495594989737482,  4,  275966134));
 
-      data[244371] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 7689461949196252397,  2,   37835472, Package.Main),
-        new SteamManifest(257510, 257515, 8579671038386532826, 28, 6427365830, Package.Main),
-        new SteamManifest(257510, 257516, 7901792711762181252,  7,     218389, Package.Main),
-        new SteamManifest(257510, 257519, 2675083093007158979,  1,    2175966, Package.Main),
-        new SteamManifest(257510, 358470, 8176613815265754262,  3,  749886317, Package.Gehenna),
-        new SteamManifest(257510, 322022, 0570457731767330233,  2,  191173592, Package.Prototype)
-      };
+      data[243520][Package.Main     ].Add(new SteamManifest(257510, 257511, 0486897345253495735,  2,   37835472));
+      data[243520][Package.Main     ].Add(new SteamManifest(257510, 257515, 0762065295327824568, 29, 6870004878));
+      data[243520][Package.Main     ].Add(new SteamManifest(257510, 257516, 7901792711762181252,  7,     218389));
+      data[243520][Package.Main     ].Add(new SteamManifest(257510, 257519, 2020897382852338977,  1,    2312159));
+      data[243520][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 3645040643832281528,  2,  704403859));
+      data[243520][Package.Prototype].Add(new SteamManifest(257510, 322022, 1221230661228297401,  4,  291798721));
 
-      data[246379] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 7720637873729107634,  2,   37919440, Package.Main),
-        new SteamManifest(257510, 257515, 4896296030980495433, 29, 6546725617, Package.Main),
-        new SteamManifest(257510, 257516, 0537534056471328674,  2,     208576, Package.Main),
-        new SteamManifest(257510, 257519, 7776793304385903116,  1,    2213167, Package.Main),
-        new SteamManifest(257510, 358470, 7419870507570765883,  3,  866850779, Package.Gehenna),
-        new SteamManifest(257510, 322022, 4423801769448698176,  2,  191045699, Package.Prototype)
-      };
+      data[244371][Package.Main     ].Add(new SteamManifest(257510, 257511, 7689461949196252397,  2,   37835472));
+      data[244371][Package.Main     ].Add(new SteamManifest(257510, 257515, 8579671038386532826, 28, 6427365830));
+      data[244371][Package.Main     ].Add(new SteamManifest(257510, 257516, 7901792711762181252,  7,     218389));
+      data[244371][Package.Main     ].Add(new SteamManifest(257510, 257519, 2675083093007158979,  1,    2175966));
+      data[244371][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 8176613815265754262,  3,  749886317));
+      data[244371][Package.Prototype].Add(new SteamManifest(257510, 322022, 0570457731767330233,  2,  191173592));
 
-      data[248139] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 1500898004646373285,  2,   37932240, Package.Main),
-        new SteamManifest(257510, 257515, 8022908710052117236, 30, 6589267934, Package.Main),
-        new SteamManifest(257510, 257516, 0537534056471328674,  2,     208576, Package.Main),
-        new SteamManifest(257510, 257519, 4793167457039384090,  1,    2226235, Package.Main),
-        new SteamManifest(257510, 358470, 9140920440213320364,  4,  896460286, Package.Gehenna),
-        new SteamManifest(257510, 322022, 5515868016021140366,  3,  191084683, Package.Prototype)
-      };
+      data[246379][Package.Main     ].Add(new SteamManifest(257510, 257511, 7720637873729107634,  2,   37919440));
+      data[246379][Package.Main     ].Add(new SteamManifest(257510, 257515, 4896296030980495433, 29, 6546725617));
+      data[246379][Package.Main     ].Add(new SteamManifest(257510, 257516, 0537534056471328674,  2,     208576));
+      data[246379][Package.Main     ].Add(new SteamManifest(257510, 257519, 7776793304385903116,  1,    2213167));
+      data[246379][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 7419870507570765883,  3,  866850779));
+      data[246379][Package.Prototype].Add(new SteamManifest(257510, 322022, 4423801769448698176,  2,  191045699));
 
-      data[248828] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 4259291835568024105,  2,   37933264, Package.Main),
-        new SteamManifest(257510, 257515, 5103279241419561908, 30, 6589271132, Package.Main),
-        new SteamManifest(257510, 257516, 0537534056471328674,  2,     208576, Package.Main),
-        new SteamManifest(257510, 257519, 7130120369117951230,  1,    2226235, Package.Main),
-        new SteamManifest(257510, 358470, 1215334353744988752,  4,  896460268, Package.Gehenna),
-        new SteamManifest(257510, 322022, 6408748820177783708,  3,  191084683, Package.Prototype)
-      };
+      data[248139][Package.Main     ].Add(new SteamManifest(257510, 257511, 1500898004646373285,  2,   37932240));
+      data[248139][Package.Main     ].Add(new SteamManifest(257510, 257515, 8022908710052117236, 30, 6589267934));
+      data[248139][Package.Main     ].Add(new SteamManifest(257510, 257516, 0537534056471328674,  2,     208576));
+      data[248139][Package.Main     ].Add(new SteamManifest(257510, 257519, 4793167457039384090,  1,    2226235));
+      data[248139][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 9140920440213320364,  4,  896460286));
+      data[248139][Package.Prototype].Add(new SteamManifest(257510, 322022, 5515868016021140366,  3,  191084683));
 
-      data[249740] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 2372465056935606724,  2,   37954768, Package.Main),
-        new SteamManifest(257510, 257515, 7774619190361198089, 29, 6590576873, Package.Main),
-        new SteamManifest(257510, 257516, 7546122753718189131,  2,     250448, Package.Main),
-        new SteamManifest(257510, 257519, 4648185825889483487,  1,    2226635, Package.Main),
-        new SteamManifest(257510, 358470, 6996102492712095516,  4,  896460342, Package.Gehenna),
-        new SteamManifest(257510, 322022, 5134711953944719494,  3,  191084684, Package.Prototype)
-      };
+      data[248828][Package.Main     ].Add(new SteamManifest(257510, 257511, 4259291835568024105,  2,   37933264));
+      data[248828][Package.Main     ].Add(new SteamManifest(257510, 257515, 5103279241419561908, 30, 6589271132));
+      data[248828][Package.Main     ].Add(new SteamManifest(257510, 257516, 0537534056471328674,  2,     208576));
+      data[248828][Package.Main     ].Add(new SteamManifest(257510, 257519, 7130120369117951230,  1,    2226235));
+      data[248828][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 1215334353744988752,  4,  896460268));
+      data[248828][Package.Prototype].Add(new SteamManifest(257510, 322022, 6408748820177783708,  3,  191084683));
 
-      data[249913] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 0104511117861601608,  2,   37954256, Package.Main),
-        new SteamManifest(257510, 257515, 8145595254539830554, 29, 6590576890, Package.Main),
-        new SteamManifest(257510, 257516, 7546122753718189131,  2,     250448, Package.Main),
-        new SteamManifest(257510, 257519, 0264858112795519304,  1,    2226635, Package.Main),
-        new SteamManifest(257510, 358470, 2832266850408399266,  4,  896460324, Package.Gehenna),
-        new SteamManifest(257510, 322022, 1518316276430466929,  3,  191084684, Package.Prototype)
-      };
+      data[249740][Package.Main     ].Add(new SteamManifest(257510, 257511, 2372465056935606724,  2,   37954768));
+      data[249740][Package.Main     ].Add(new SteamManifest(257510, 257515, 7774619190361198089, 29, 6590576873));
+      data[249740][Package.Main     ].Add(new SteamManifest(257510, 257516, 7546122753718189131,  2,     250448));
+      data[249740][Package.Main     ].Add(new SteamManifest(257510, 257519, 4648185825889483487,  1,    2226635));
+      data[249740][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 6996102492712095516,  4,  896460342));
+      data[249740][Package.Prototype].Add(new SteamManifest(257510, 322022, 5134711953944719494,  3,  191084684));
 
-      data[250756] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 1813793007507355582,  4,   84907936, Package.Main),
-        new SteamManifest(257510, 257515, 1726824934552610516, 29, 6604599929, Package.Main),
-        new SteamManifest(257510, 257516, 1646028800945546522,  4,     531616, Package.Main),
-        new SteamManifest(257510, 257519, 7529726526274038229,  1,    2230935, Package.Main),
-        new SteamManifest(257510, 358470, 5457565769128401790,  4,  896460334, Package.Gehenna),
-        new SteamManifest(257510, 322022, 6332807582508063459,  3,  191084684, Package.Prototype)
-      };
+      data[249913][Package.Main     ].Add(new SteamManifest(257510, 257511, 0104511117861601608,  2,   37954256));
+      data[249913][Package.Main     ].Add(new SteamManifest(257510, 257515, 8145595254539830554, 29, 6590576890));
+      data[249913][Package.Main     ].Add(new SteamManifest(257510, 257516, 7546122753718189131,  2,     250448));
+      data[249913][Package.Main     ].Add(new SteamManifest(257510, 257519, 0264858112795519304,  1,    2226635));
+      data[249913][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 2832266850408399266,  4,  896460324));
+      data[249913][Package.Prototype].Add(new SteamManifest(257510, 322022, 1518316276430466929,  3,  191084684));
 
-      data[252786] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 4797710291018151156,  4,   84907936, Package.Main),
-        new SteamManifest(257510, 257515, 3411862904639819627, 29, 6604599937, Package.Main),
-        new SteamManifest(257510, 257516, 1646028800945546522,  4,     531616, Package.Main),
-        new SteamManifest(257510, 257519, 7754615816270172495,  1,    2230935, Package.Main),
-        new SteamManifest(257510, 358470, 1181179272206183222,  4,  896460247, Package.Gehenna),
-        new SteamManifest(257510, 322022, 6635364740942276299,  3,  191084684, Package.Prototype)
-      };
+      data[250756][Package.Main     ].Add(new SteamManifest(257510, 257511, 1813793007507355582,  4,   84907936));
+      data[250756][Package.Main     ].Add(new SteamManifest(257510, 257515, 1726824934552610516, 29, 6604599929));
+      data[250756][Package.Main     ].Add(new SteamManifest(257510, 257516, 1646028800945546522,  4,     531616));
+      data[250756][Package.Main     ].Add(new SteamManifest(257510, 257519, 7529726526274038229,  1,    2230935));
+      data[250756][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 5457565769128401790,  4,  896460334));
+      data[250756][Package.Prototype].Add(new SteamManifest(257510, 322022, 6332807582508063459,  3,  191084684));
 
-      data[258375] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 0291313986193809433,  4,   84569504, Package.Main),
-        new SteamManifest(257510, 257515, 6044225467093048211, 29, 6667251114, Package.Main),
-        new SteamManifest(257510, 257516, 1646028800945546522,  4,     531616, Package.Main),
-        new SteamManifest(257510, 257519, 1808951156598981957,  1,    2250567, Package.Main),
-        new SteamManifest(257510, 358470, 5851055062358757678,  4,  896451088, Package.Gehenna),
-        new SteamManifest(257510, 322022, 9214799288230159850,  3,  191280304, Package.Prototype)
-      };
+      data[252786][Package.Main     ].Add(new SteamManifest(257510, 257511, 4797710291018151156,  4,   84907936));
+      data[252786][Package.Main     ].Add(new SteamManifest(257510, 257515, 3411862904639819627, 29, 6604599937));
+      data[252786][Package.Main     ].Add(new SteamManifest(257510, 257516, 1646028800945546522,  4,     531616));
+      data[252786][Package.Main     ].Add(new SteamManifest(257510, 257519, 7754615816270172495,  1,    2230935));
+      data[252786][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 1181179272206183222,  4,  896460247));
+      data[252786][Package.Prototype].Add(new SteamManifest(257510, 322022, 6635364740942276299,  3,  191084684));
 
-      data[260924] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 0499590387152058814,  4,   86096800, Package.Main),
-        new SteamManifest(257510, 257515, 8206832965751498451, 29, 6667399585, Package.Main),
-        new SteamManifest(257510, 257516, 1646028800945546522,  4,     531616, Package.Main),
-        new SteamManifest(257510, 257519, 3398982331085565137,  1,    2250607, Package.Main),
-        new SteamManifest(257510, 358470, 4919986680879759016,  4,  902448838, Package.Gehenna),
-        new SteamManifest(257510, 322022, 7503933396680891180,  3,  191280306, Package.Prototype)
-      };
+      data[258375][Package.Main     ].Add(new SteamManifest(257510, 257511, 0291313986193809433,  4,   84569504));
+      data[258375][Package.Main     ].Add(new SteamManifest(257510, 257515, 6044225467093048211, 29, 6667251114));
+      data[258375][Package.Main     ].Add(new SteamManifest(257510, 257516, 1646028800945546522,  4,     531616));
+      data[258375][Package.Main     ].Add(new SteamManifest(257510, 257519, 1808951156598981957,  1,    2250567));
+      data[258375][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 5851055062358757678,  4,  896451088));
+      data[258375][Package.Prototype].Add(new SteamManifest(257510, 322022, 9214799288230159850,  3,  191280304));
 
-      data[264510] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 4661937614683834332,  4,   86476576, Package.Main),
-        new SteamManifest(257510, 257515, 7995925049155399775, 29, 6677789906, Package.Main),
-        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
-        new SteamManifest(257510, 257519, 2063011968231605882,  1,    2253792, Package.Main),
-        new SteamManifest(257510, 358470, 8410067891696867813,  4,  902448650, Package.Gehenna),
-        new SteamManifest(257510, 322022, 5194706371718824589,  3,  191280314, Package.Prototype)
-      };
+      data[260924][Package.Main     ].Add(new SteamManifest(257510, 257511, 0499590387152058814,  4,   86096800));
+      data[260924][Package.Main     ].Add(new SteamManifest(257510, 257515, 8206832965751498451, 29, 6667399585));
+      data[260924][Package.Main     ].Add(new SteamManifest(257510, 257516, 1646028800945546522,  4,     531616));
+      data[260924][Package.Main     ].Add(new SteamManifest(257510, 257519, 3398982331085565137,  1,    2250607));
+      data[260924][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 4919986680879759016,  4,  902448838));
+      data[260924][Package.Prototype].Add(new SteamManifest(257510, 322022, 7503933396680891180,  3,  191280306));
 
-      data[267252] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 0914480456153849155,  4,   86718752, Package.Main),
-        new SteamManifest(257510, 257515, 8897416572811879523, 29, 6704813319, Package.Main),
-        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
-        new SteamManifest(257510, 257519, 3339621383432167258,  1,    2262052, Package.Main),
-        new SteamManifest(257510, 358470, 7441510589944616318,  4,  902448620, Package.Gehenna),
-        new SteamManifest(257510, 322022, 3417810446044054571,  3,  191280318, Package.Prototype)
-      };
+      data[264510][Package.Main     ].Add(new SteamManifest(257510, 257511, 4661937614683834332,  4,   86476576));
+      data[264510][Package.Main     ].Add(new SteamManifest(257510, 257515, 7995925049155399775, 29, 6677789906));
+      data[264510][Package.Main     ].Add(new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400));
+      data[264510][Package.Main     ].Add(new SteamManifest(257510, 257519, 2063011968231605882,  1,    2253792));
+      data[264510][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 8410067891696867813,  4,  902448650));
+      data[264510][Package.Prototype].Add(new SteamManifest(257510, 322022, 5194706371718824589,  3,  191280314));
 
-      data[269335] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 4361546767985939876,  4,   87218976, Package.Main),
-        new SteamManifest(257510, 257515, 2778697671525586970, 29, 6704324599, Package.Main),
-        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
-        new SteamManifest(257510, 257519, 3429893718454775303,  1,    2261892, Package.Main),
-        new SteamManifest(257510, 358470, 2971770452830915701,  4,  902448648, Package.Gehenna),
-        new SteamManifest(257510, 322022, 2804553596758319623,  3,  191280313, Package.Prototype)
-      };
+      data[267252][Package.Main     ].Add(new SteamManifest(257510, 257511, 0914480456153849155,  4,   86718752));
+      data[267252][Package.Main     ].Add(new SteamManifest(257510, 257515, 8897416572811879523, 29, 6704813319));
+      data[267252][Package.Main     ].Add(new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400));
+      data[267252][Package.Main     ].Add(new SteamManifest(257510, 257519, 3339621383432167258,  1,    2262052));
+      data[267252][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 7441510589944616318,  4,  902448620));
+      data[267252][Package.Prototype].Add(new SteamManifest(257510, 322022, 3417810446044054571,  3,  191280318));
 
-      data[277544] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 4438368920362581908,  4,   87489312, Package.Main),
-        new SteamManifest(257510, 257515, 8527295741256308631, 29, 6701407239, Package.Main),
-        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
-        new SteamManifest(257510, 257519, 8707002697175431137,  1,    2261012, Package.Main),
-        new SteamManifest(257510, 358470, 5026831778825708639,  4,  902535678, Package.Gehenna),
-        new SteamManifest(257510, 322022, 4959862740532303621,  3,  191280317, Package.Prototype)
-      };
+      data[269335][Package.Main     ].Add(new SteamManifest(257510, 257511, 4361546767985939876,  4,   87218976));
+      data[269335][Package.Main     ].Add(new SteamManifest(257510, 257515, 2778697671525586970, 29, 6704324599));
+      data[269335][Package.Main     ].Add(new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400));
+      data[269335][Package.Main     ].Add(new SteamManifest(257510, 257519, 3429893718454775303,  1,    2261892));
+      data[269335][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 2971770452830915701,  4,  902448648));
+      data[269335][Package.Prototype].Add(new SteamManifest(257510, 322022, 2804553596758319623,  3,  191280313));
 
-      data[284152] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 2310534095082994736,  4,   87675168, Package.Main),
-        new SteamManifest(257510, 257515, 6023749242906446787, 29, 6701585582, Package.Main),
-        new SteamManifest(257510, 257516, 0827084533033961837,  6,     8172400, Package.Main),
-        new SteamManifest(257510, 257519, 3309514767764105231,  1,    2261052, Package.Main),
-        new SteamManifest(257510, 358470, 6462721285409783950,  4,  902535584, Package.Gehenna),
-        new SteamManifest(257510, 322022, 6922743269332565255,  3,  191280316, Package.Prototype)
-      };
+      data[277544][Package.Main     ].Add(new SteamManifest(257510, 257511, 4438368920362581908,  4,   87489312));
+      data[277544][Package.Main     ].Add(new SteamManifest(257510, 257515, 8527295741256308631, 29, 6701407239));
+      data[277544][Package.Main     ].Add(new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400));
+      data[277544][Package.Main     ].Add(new SteamManifest(257510, 257519, 8707002697175431137,  1,    2261012));
+      data[277544][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 5026831778825708639,  4,  902535678));
+      data[277544][Package.Prototype].Add(new SteamManifest(257510, 322022, 4959862740532303621,  3,  191280317));
 
-      data[291145] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 2517236650746590986,  4,   87096608, Package.Main),
-        new SteamManifest(257510, 257515, 5170392634591662639, 29, 6726169973, Package.Main),
-        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
-        new SteamManifest(257510, 257519, 5158478294883956711,  1,    2268552, Package.Main),
-        new SteamManifest(257510, 358470, 3878145609496862471,  4,  902535704, Package.Gehenna),
-        new SteamManifest(257510, 322022, 0330496884825252439,  3,  191280317, Package.Prototype)
-      };
+      data[284152][Package.Main     ].Add(new SteamManifest(257510, 257511, 2310534095082994736,  4,   87675168));
+      data[284152][Package.Main     ].Add(new SteamManifest(257510, 257515, 6023749242906446787, 29, 6701585582));
+      data[284152][Package.Main     ].Add(new SteamManifest(257510, 257516, 0827084533033961837,  6,     8172400));
+      data[284152][Package.Main     ].Add(new SteamManifest(257510, 257519, 3309514767764105231,  1,    2261052));
+      data[284152][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 6462721285409783950,  4,  902535584));
+      data[284152][Package.Prototype].Add(new SteamManifest(257510, 322022, 6922743269332565255,  3,  191280316));
 
-      data[293384] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 7465431023497269772,  4,   87130912, Package.Main),
-        new SteamManifest(257510, 257515, 3921528168366102418, 29, 6701195630, Package.Main),
-        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
-        new SteamManifest(257510, 257519, 2400271216751877709,  1,    2260932, Package.Main),
-        new SteamManifest(257510, 358470, 3689687611838010639,  4,  902535631, Package.Gehenna),
-        new SteamManifest(257510, 322022, 6864442709661062902,  3,  191280316, Package.Prototype)
-      };
+      data[291145][Package.Main     ].Add(new SteamManifest(257510, 257511, 2517236650746590986,  4,   87096608));
+      data[291145][Package.Main     ].Add(new SteamManifest(257510, 257515, 5170392634591662639, 29, 6726169973));
+      data[291145][Package.Main     ].Add(new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400));
+      data[291145][Package.Main     ].Add(new SteamManifest(257510, 257519, 5158478294883956711,  1,    2268552));
+      data[291145][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 3878145609496862471,  4,  902535704));
+      data[291145][Package.Prototype].Add(new SteamManifest(257510, 322022, 0330496884825252439,  3,  191280317));
 
-      data[300763] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 0236601650031060048,  4,   87206688, Package.Main),
-        new SteamManifest(257510, 257515, 3706310912589354532, 29, 6701203978, Package.Main),
-        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
-        new SteamManifest(257510, 257519, 8838046835968752341,  1,    2260932, Package.Main),
-        new SteamManifest(257510, 358470, 2608271957197798008,  4,  902535566, Package.Gehenna),
-        new SteamManifest(257510, 322022, 1944742430107480164,  3,  191280316, Package.Prototype)
-      };
+      data[293384][Package.Main     ].Add(new SteamManifest(257510, 257511, 7465431023497269772,  4,   87130912));
+      data[293384][Package.Main     ].Add(new SteamManifest(257510, 257515, 3921528168366102418, 29, 6701195630));
+      data[293384][Package.Main     ].Add(new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400));
+      data[293384][Package.Main     ].Add(new SteamManifest(257510, 257519, 2400271216751877709,  1,    2260932));
+      data[293384][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 3689687611838010639,  4,  902535631));
+      data[293384][Package.Prototype].Add(new SteamManifest(257510, 322022, 6864442709661062902,  3,  191280316));
 
-      data[301136] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 5351514903097441265,  4,   87213344, Package.Main),
-        new SteamManifest(257510, 257515, 0518026948382674055, 29, 6701203091, Package.Main),
-        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
-        new SteamManifest(257510, 257519, 3588926819998531108,  1,    2260932, Package.Main),
-        new SteamManifest(257510, 358470, 1599787433380595759,  4,  902535677, Package.Gehenna),
-        new SteamManifest(257510, 322022, 2866879691166241287,  3,  191280316, Package.Prototype)
-      };
+      data[300763][Package.Main     ].Add(new SteamManifest(257510, 257511, 0236601650031060048,  4,   87206688));
+      data[300763][Package.Main     ].Add(new SteamManifest(257510, 257515, 3706310912589354532, 29, 6701203978));
+      data[300763][Package.Main     ].Add(new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400));
+      data[300763][Package.Main     ].Add(new SteamManifest(257510, 257519, 8838046835968752341,  1,    2260932));
+      data[300763][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 2608271957197798008,  4,  902535566));
+      data[300763][Package.Prototype].Add(new SteamManifest(257510, 322022, 1944742430107480164,  3,  191280316));
 
-      data[326589] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 7222986970071829007,  4,   91624224, Package.Main),
-        new SteamManifest(257510, 257515, 3164152563056127398, 29, 6770687163, Package.Main),
-        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
-        new SteamManifest(257510, 257519, 7686943783455980924,  1,    2282132, Package.Main),
-        new SteamManifest(257510, 358470, 5178136109328124898,  4,  902817535, Package.Gehenna),
-        new SteamManifest(257510, 322022, 1999687630096794293,  3,  191280306, Package.Prototype)
-      };
+      data[301136][Package.Main     ].Add(new SteamManifest(257510, 257511, 5351514903097441265,  4,   87213344));
+      data[301136][Package.Main     ].Add(new SteamManifest(257510, 257515, 0518026948382674055, 29, 6701203091));
+      data[301136][Package.Main     ].Add(new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400));
+      data[301136][Package.Main     ].Add(new SteamManifest(257510, 257519, 3588926819998531108,  1,    2260932));
+      data[301136][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 1599787433380595759,  4,  902535677));
+      data[301136][Package.Prototype].Add(new SteamManifest(257510, 322022, 2866879691166241287,  3,  191280316));
 
-      data[424910] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 4445925190137047197,  2,   66084984, Package.Main),
-        new SteamManifest(257510, 257515, 5833630477596020402, 49, 5634581190, Package.Main),
-        new SteamManifest(257510, 257516, 5450066894376160295, 11,   33548240, Package.Main),
-        new SteamManifest(257510, 358470, 0446988425271855249,  2,  777810959, Package.Gehenna),
-        new SteamManifest(257510, 322022, 1251221992794837269,  2,  201570650, Package.Prototype)
-      };
+      data[326589][Package.Main     ].Add(new SteamManifest(257510, 257511, 7222986970071829007,  4,   91624224));
+      data[326589][Package.Main     ].Add(new SteamManifest(257510, 257515, 3164152563056127398, 29, 6770687163));
+      data[326589][Package.Main     ].Add(new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400));
+      data[326589][Package.Main     ].Add(new SteamManifest(257510, 257519, 7686943783455980924,  1,    2282132));
+      data[326589][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 5178136109328124898,  4,  902817535));
+      data[326589][Package.Prototype].Add(new SteamManifest(257510, 322022, 1999687630096794293,  3,  191280306));
 
-      data[426014] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 3586505834137878681,  2,   66084976, Package.Main),
-        new SteamManifest(257510, 257515, 6301775319056368422, 50, 5663034799, Package.Main),
-        new SteamManifest(257510, 257516, 8705936455967316907, 11,   33548240, Package.Main),
-        new SteamManifest(257510, 358470, 3702226411907956172,  3,  786618977, Package.Gehenna),
-        new SteamManifest(257510, 322022, 1538185595447097219,  2,  201570963, Package.Prototype)
-      };
+      data[424910][Package.Main     ].Add(new SteamManifest(257510, 257511, 4445925190137047197,  2,   66084984));
+      data[424910][Package.Main     ].Add(new SteamManifest(257510, 257515, 5833630477596020402, 49, 5634581190));
+      data[424910][Package.Main     ].Add(new SteamManifest(257510, 257516, 5450066894376160295, 11,   33548240));
+      data[424910][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 0446988425271855249,  2,  777810959));
+      data[424910][Package.Prototype].Add(new SteamManifest(257510, 322022, 1251221992794837269,  2,  201570650));
 
-      data[429074] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 8159846362257674313,  2,   66084984, Package.Main),
-        new SteamManifest(257510, 257515, 2713051319254128482, 50, 5663034511, Package.Main),
-        new SteamManifest(257510, 257516, 3680540037408603213, 11,   33548240, Package.Main),
-        new SteamManifest(257510, 358470, 6406142202705981356,  3,  786732859, Package.Gehenna),
-        new SteamManifest(257510, 322022, 6956365166520441230,  2,  201571015, Package.Prototype)
-      };
+      data[426014][Package.Main     ].Add(new SteamManifest(257510, 257511, 3586505834137878681,  2,   66084976));
+      data[426014][Package.Main     ].Add(new SteamManifest(257510, 257515, 6301775319056368422, 50, 5663034799));
+      data[426014][Package.Main     ].Add(new SteamManifest(257510, 257516, 8705936455967316907, 11,   33548240));
+      data[426014][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 3702226411907956172,  3,  786618977));
+      data[426014][Package.Prototype].Add(new SteamManifest(257510, 322022, 1538185595447097219,  2,  201570963));
 
-      data[440323] = new List<SteamManifest> {
-        new SteamManifest(257510, 257511, 0799213806328220919,  2,   66117856, Package.Main),
-        new SteamManifest(257510, 257515, 3279814669572335644, 52, 5667320739, Package.Main),
-        new SteamManifest(257510, 257516, 7924825898116512954, 12,   34207184, Package.Main),
-        new SteamManifest(257510, 322022, 8229910699963260352,  2,  201589569, Package.Prototype),
-        new SteamManifest(257510, 358470, 0981576150363927305,  3,  883262060, Package.Gehenna)
-      };
+      data[429074][Package.Main     ].Add(new SteamManifest(257510, 257511, 8159846362257674313,  2,   66084984));
+      data[429074][Package.Main     ].Add(new SteamManifest(257510, 257515, 2713051319254128482, 50, 5663034511));
+      data[429074][Package.Main     ].Add(new SteamManifest(257510, 257516, 3680540037408603213, 11,   33548240));
+      data[429074][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 6406142202705981356,  3,  786732859));
+      data[429074][Package.Prototype].Add(new SteamManifest(257510, 322022, 6956365166520441230,  2,  201571015));
+
+      data[440323][Package.Main     ].Add(new SteamManifest(257510, 257511, 0799213806328220919,  2,   66117856));
+      data[440323][Package.Main     ].Add(new SteamManifest(257510, 257515, 3279814669572335644, 52, 5667320739));
+      data[440323][Package.Main     ].Add(new SteamManifest(257510, 257516, 7924825898116512954, 12,   34207184));
+      data[440323][Package.Gehenna  ].Add(new SteamManifest(257510, 358470, 0981576150363927305,  3,  883262060));
+      data[440323][Package.Prototype].Add(new SteamManifest(257510, 322022, 8229910699963260352,  2,  201589569));
 
       System.Diagnostics.Debug.Assert(
         data.Keys.All(ver => allVersions.Contains(ver)) && data.Keys.Count == allVersions.Count,

--- a/ManifestData.cs
+++ b/ManifestData.cs
@@ -1,18 +1,26 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace TalosDownpatcher {
-  public class Datum {
-    public long manifest;
-    public int numFiles; // @Cleanup: Unused, but definitely should be (at least for validation).
-    public long size;
-    public Datum(long manifest, int numFiles, long size) {
-      this.manifest = manifest;
+  public class SteamManifest {
+    public readonly int appId;
+    public readonly int depotId;
+    public readonly long manifestId;
+
+    public readonly int numFiles; // @Cleanup: Unused, but definitely should be (at least for validation).
+    public readonly long size;
+    public readonly Package package;
+    public SteamManifest(int appId, int depotId, long manifestId, int numFiles, long size, Package package) {
+      this.appId = appId;
+      this.depotId = depotId;
+      this.manifestId = manifestId;
       this.numFiles = numFiles;
       this.size = size;
+      this.package = package;
     }
   }
 
-  public class ManifestData {
+  public static class ManifestData {
     public static readonly List<int> commonVersions = new List<int> {
       440323, 326589, 301136, 244371
     };
@@ -23,251 +31,332 @@ namespace TalosDownpatcher {
       243520, 226087, 224995, 224531, 223249, 222477, 221394, 220996,
       220675, 220625, 220480
     };
+    // Possibly replace with:
+    // public static List<int> allVersions { get { return data.Keys.ToList(); } }
 
-    public static readonly int GEHENNA = 358470;
-    public static readonly int PROTOTYPE = 322022;
-    public static readonly List<int> depots = new List<int> {257516, 257519, 257511, 257515};
-
-    private Dictionary<int, Dictionary<int, Datum>> data;
-
-    // Helper function so that data can be private. This also helps the runtime avoid accidentally copying data[version] as an intermediate.
-    public Datum this[int version, int depot] {
-      get {return data[version][depot];}
-    }
-
-    public long GetDownloadSize(int version, Package package) {
-      if (package == Package.Main) {
-        long totalDownloadSize = 0;
-        foreach (var depot in depots) totalDownloadSize += this[version, depot].size;
-        return totalDownloadSize;
-      } else if (package == Package.Gehenna) {
-        return this[version, GEHENNA].size;
-      } else if (package == Package.Prototype) {
-        return this[version, PROTOTYPE].size;
-      } else {
-        return 0;
+    public static long GetDownloadSize(int version, Package package = Package.All) {
+      long totalDownloadSize = 0;
+      foreach (var manifest in GetManifestsForVersion(version, package)) {
+        totalDownloadSize += manifest.size;
       }
+      return totalDownloadSize;
     }
 
-    public ManifestData() {
-      data = new Dictionary<int, Dictionary<int, Datum>>();
-      foreach (var version in allVersions) data[version] = new Dictionary<int, Datum>();
+    public static IEnumerable<SteamManifest> GetManifestsForVersion(int version, Package package = Package.All) {
+      return data[version].Where(m => package == Package.All || package == m.package);
+    }
 
-      data[440323][257511] = new Datum(0799213806328220919, 2, 66117856);
-      data[429074][257511] = new Datum(8159846362257674313, 2, 66084984);
-      data[426014][257511] = new Datum(3586505834137878681, 2, 66084976);
-      data[424910][257511] = new Datum(4445925190137047197, 2, 66084984);
-      data[326589][257511] = new Datum(7222986970071829007, 4, 91624224);
-      data[301136][257511] = new Datum(5351514903097441265, 4, 87213344);
-      data[300763][257511] = new Datum(0236601650031060048, 4, 87206688);
-      data[293384][257511] = new Datum(7465431023497269772, 4, 87130912);
-      data[291145][257511] = new Datum(2517236650746590986, 4, 87096608);
-      data[284152][257511] = new Datum(2310534095082994736, 4, 87675168);
-      data[277544][257511] = new Datum(4438368920362581908, 4, 87489312);
-      data[269335][257511] = new Datum(4361546767985939876, 4, 87218976);
-      data[267252][257511] = new Datum(0914480456153849155, 4, 86718752);
-      data[264510][257511] = new Datum(4661937614683834332, 4, 86476576);
-      data[260924][257511] = new Datum(0499590387152058814, 4, 86096800);
-      data[258375][257511] = new Datum(0291313986193809433, 4, 84569504);
-      data[252786][257511] = new Datum(4797710291018151156, 4, 84907936);
-      data[250756][257511] = new Datum(1813793007507355582, 4, 84907936);
-      data[249913][257511] = new Datum(0104511117861601608, 2, 37954256);
-      data[249740][257511] = new Datum(2372465056935606724, 2, 37954768);
-      data[248828][257511] = new Datum(4259291835568024105, 2, 37933264);
-      data[248139][257511] = new Datum(1500898004646373285, 2, 37932240);
-      data[246379][257511] = new Datum(7720637873729107634, 2, 37919440);
-      data[244371][257511] = new Datum(7689461949196252397, 2, 37835472);
-      data[243520][257511] = new Datum(0486897345253495735, 2, 37835472);
-      data[226087][257511] = new Datum(2501832898327740448, 2, 38003408);
-      data[224995][257511] = new Datum(9130874505093356390, 2, 38000336);
-      data[224531][257511] = new Datum(3207947001105705384, 2, 37991120);
-      data[223249][257511] = new Datum(4657839721186080333, 2, 49014480);
-      data[222477][257511] = new Datum(0918811395787437543, 2, 49005264);
-      data[221394][257511] = new Datum(1222567553988779631, 2, 48947920);
-      data[220996][257511] = new Datum(3475103749484918333, 2, 48912080);
-      data[220675][257511] = new Datum(2018192542376932921, 2, 48900816);
-      data[220625][257511] = new Datum(8087374737096894864, 2, 48901328);
-      data[220480][257511] = new Datum(4122334240058475272, 2, 48908496);
+    private static readonly Dictionary<int, List<SteamManifest>> data = InitData();
+    private static Dictionary<int, List<SteamManifest>> InitData() {
+      Dictionary<int, List<SteamManifest>> data = new Dictionary<int, List<SteamManifest>>();
 
-      data[440323][257515] = new Datum(3279814669572335644, 52, 5667320739);
-      data[429074][257515] = new Datum(2713051319254128482, 50, 5663034511);
-      data[426014][257515] = new Datum(6301775319056368422, 50, 5663034799);
-      data[424910][257515] = new Datum(5833630477596020402, 49, 5634581190);
-      data[326589][257515] = new Datum(3164152563056127398, 29, 6770687163);
-      data[301136][257515] = new Datum(0518026948382674055, 29, 6701203091);
-      data[300763][257515] = new Datum(3706310912589354532, 29, 6701203978);
-      data[293384][257515] = new Datum(3921528168366102418, 29, 6701195630);
-      data[291145][257515] = new Datum(5170392634591662639, 29, 6726169973);
-      data[284152][257515] = new Datum(6023749242906446787, 29, 6701585582);
-      data[277544][257515] = new Datum(8527295741256308631, 29, 6701407239);
-      data[269335][257515] = new Datum(2778697671525586970, 29, 6704324599);
-      data[267252][257515] = new Datum(8897416572811879523, 29, 6704813319);
-      data[264510][257515] = new Datum(7995925049155399775, 29, 6677789906);
-      data[260924][257515] = new Datum(8206832965751498451, 29, 6667399585);
-      data[258375][257515] = new Datum(6044225467093048211, 29, 6667251114);
-      data[252786][257515] = new Datum(3411862904639819627, 29, 6604599937);
-      data[250756][257515] = new Datum(1726824934552610516, 29, 6604599929);
-      data[249913][257515] = new Datum(8145595254539830554, 29, 6590576890);
-      data[249740][257515] = new Datum(7774619190361198089, 29, 6590576873);
-      data[248828][257515] = new Datum(5103279241419561908, 30, 6589271132);
-      data[248139][257515] = new Datum(8022908710052117236, 30, 6589267934);
-      data[246379][257515] = new Datum(4896296030980495433, 29, 6546725617);
-      data[244371][257515] = new Datum(8579671038386532826, 28, 6427365830);
-      data[243520][257515] = new Datum(0762065295327824568, 29, 6870004878);
-      data[226087][257515] = new Datum(3826319505876650203, 29, 6282258753);
-      data[224995][257515] = new Datum(4840744566182207229, 28, 6281389510);
-      data[224531][257515] = new Datum(5798939509479840711, 28, 6281382910);
-      data[223249][257515] = new Datum(8304752583573271963, 27, 6094446741);
-      data[222477][257515] = new Datum(6267514976170907571, 27, 6094446568);
-      data[221394][257515] = new Datum(7204783264154690101, 27, 5842288583);
-      data[220996][257515] = new Datum(0415067456888111848, 27, 5439377389);
-      data[220675][257515] = new Datum(8986158524600611840, 32, 5217247413);
-      data[220625][257515] = new Datum(3617089317964903627, 32, 5217247608);
-      data[220480][257515] = new Datum(1348826399794024471, 32, 5055625401);
+      data[220480] = new List<SteamManifest>() {
+        new SteamManifest(257510, 257511, 4122334240058475272, 2, 48908496, Package.Main),
+        new SteamManifest(257510, 257515, 1348826399794024471, 32, 5055625401, Package.Main),
+        new SteamManifest(257510, 257516, 1237958166729860756, 6, 117245, Package.Main),
+        new SteamManifest(257510, 257519, 2322040020544521685, 1, 1739595, Package.Main),
+        new SteamManifest(257510, 322022, 2824340380872620137, 3, 172228256, Package.Prototype)
+      };
 
-      data[440323][257516] = new Datum(7924825898116512954, 12, 34207184);
-      data[429074][257516] = new Datum(3680540037408603213, 11, 33548240);
-      data[426014][257516] = new Datum(8705936455967316907, 11, 33548240);
-      data[424910][257516] = new Datum(5450066894376160295, 11, 33548240);
-      data[326589][257516] = new Datum(0827084533033961837, 6, 8172400);
-      data[301136][257516] = new Datum(0827084533033961837, 6, 8172400);
-      data[300763][257516] = new Datum(0827084533033961837, 6, 8172400);
-      data[293384][257516] = new Datum(0827084533033961837, 6, 8172400);
-      data[291145][257516] = new Datum(0827084533033961837, 6, 8172400);
-      data[284152][257516] = new Datum(0827084533033961837, 6, 8172400);
-      data[277544][257516] = new Datum(0827084533033961837, 6, 8172400);
-      data[269335][257516] = new Datum(0827084533033961837, 6, 8172400);
-      data[267252][257516] = new Datum(0827084533033961837, 6, 8172400);
-      data[264510][257516] = new Datum(0827084533033961837, 6, 8172400);
-      data[260924][257516] = new Datum(1646028800945546522, 4, 531616);
-      data[258375][257516] = new Datum(1646028800945546522, 4, 531616);
-      data[252786][257516] = new Datum(1646028800945546522, 4, 531616);
-      data[250756][257516] = new Datum(1646028800945546522, 4, 531616);
-      data[249913][257516] = new Datum(7546122753718189131, 2, 250448);
-      data[249740][257516] = new Datum(7546122753718189131, 2, 250448);
-      data[248828][257516] = new Datum(0537534056471328674, 2, 208576);
-      data[248139][257516] = new Datum(0537534056471328674, 2, 208576);
-      data[246379][257516] = new Datum(0537534056471328674, 2, 208576);
-      data[244371][257516] = new Datum(7901792711762181252, 7, 218389);
-      data[243520][257516] = new Datum(7901792711762181252, 7, 218389);
-      data[226087][257516] = new Datum(1237958166729860756, 6, 117245);
-      data[224995][257516] = new Datum(1237958166729860756, 6, 117245);
-      data[224531][257516] = new Datum(1237958166729860756, 6, 117245);
-      data[223249][257516] = new Datum(1237958166729860756, 6, 117245);
-      data[222477][257516] = new Datum(1237958166729860756, 6, 117245);
-      data[221394][257516] = new Datum(1237958166729860756, 6, 117245);
-      data[220996][257516] = new Datum(1237958166729860756, 6, 117245);
-      data[220675][257516] = new Datum(1237958166729860756, 6, 117245);
-      data[220625][257516] = new Datum(1237958166729860756, 6, 117245);
-      data[220480][257516] = new Datum(1237958166729860756, 6, 117245);
+      data[220625] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 8087374737096894864,  2,   48901328, Package.Main),
+        new SteamManifest(257510, 257515, 3617089317964903627, 32, 5217247608, Package.Main),
+        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
+        new SteamManifest(257510, 257519, 1272083368566319066,  1,    1789447, Package.Main),
+        new SteamManifest(257510, 322022, 8183524469048336858,  3,  206907989, Package.Prototype)
+      };
 
-      data[440323][257519] = new Datum(1170103677162582368, 0, 0);
-      data[429074][257519] = new Datum(1170103677162582368, 0, 0);
-      data[426014][257519] = new Datum(1170103677162582368, 0, 0);
-      data[424910][257519] = new Datum(1170103677162582368, 0, 0);
-      data[326589][257519] = new Datum(7686943783455980924, 1, 2282132);
-      data[301136][257519] = new Datum(3588926819998531108, 1, 2260932);
-      data[300763][257519] = new Datum(8838046835968752341, 1, 2260932);
-      data[293384][257519] = new Datum(2400271216751877709, 1, 2260932);
-      data[291145][257519] = new Datum(5158478294883956711, 1, 2268552);
-      data[284152][257519] = new Datum(3309514767764105231, 1, 2261052);
-      data[277544][257519] = new Datum(8707002697175431137, 1, 2261012);
-      data[269335][257519] = new Datum(3429893718454775303, 1, 2261892);
-      data[267252][257519] = new Datum(3339621383432167258, 1, 2262052);
-      data[264510][257519] = new Datum(2063011968231605882, 1, 2253792);
-      data[260924][257519] = new Datum(3398982331085565137, 1, 2250607);
-      data[258375][257519] = new Datum(1808951156598981957, 1, 2250567);
-      data[252786][257519] = new Datum(7754615816270172495, 1, 2230935);
-      data[250756][257519] = new Datum(7529726526274038229, 1, 2230935);
-      data[249913][257519] = new Datum(0264858112795519304, 1, 2226635);
-      data[249740][257519] = new Datum(4648185825889483487, 1, 2226635);
-      data[248828][257519] = new Datum(7130120369117951230, 1, 2226235);
-      data[248139][257519] = new Datum(4793167457039384090, 1, 2226235);
-      data[246379][257519] = new Datum(7776793304385903116, 1, 2213167);
-      data[244371][257519] = new Datum(2675083093007158979, 1, 2175966);
-      data[243520][257519] = new Datum(2020897382852338977, 1, 2312159);
-      data[226087][257519] = new Datum(5081265059426016345, 1, 2117916);
-      data[224995][257519] = new Datum(0660166059336687264, 1, 2117568);
-      data[224531][257519] = new Datum(3565289474630779855, 1, 2117568);
-      data[223249][257519] = new Datum(7835318215284690246, 1, 2059976);
-      data[222477][257519] = new Datum(6671071736059004158, 1, 2059976);
-      data[221394][257519] = new Datum(6019585236142413402, 1, 1981411);
-      data[220996][257519] = new Datum(4906101680219337427, 1, 1858219);
-      data[220675][257519] = new Datum(4554990112195176406, 1, 1789447);
-      data[220625][257519] = new Datum(1272083368566319066, 1, 1789447);
-      data[220480][257519] = new Datum(2322040020544521685, 1, 1739595);
+      data[220675] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 2018192542376932921,  2,   48900816, Package.Main),
+        new SteamManifest(257510, 257515, 8986158524600611840, 32, 5217247413, Package.Main),
+        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
+        new SteamManifest(257510, 257519, 4554990112195176406,  1,    1789447, Package.Main),
+        new SteamManifest(257510, 322022, 4383443687812477256,  3,  206909511, Package.Prototype)
+      };
 
-      data[440323][358470] = new Datum(0981576150363927305, 3, 883262060);
-      data[429074][358470] = new Datum(6406142202705981356, 3, 786732859);
-      data[426014][358470] = new Datum(3702226411907956172, 3, 786618977);
-      data[424910][358470] = new Datum(0446988425271855249, 2, 777810959);
-      data[326589][358470] = new Datum(5178136109328124898, 4, 902817535);
-      data[301136][358470] = new Datum(1599787433380595759, 4, 902535677);
-      data[300763][358470] = new Datum(2608271957197798008, 4, 902535566);
-      data[293384][358470] = new Datum(3689687611838010639, 4, 902535631);
-      data[291145][358470] = new Datum(3878145609496862471, 4, 902535704);
-      data[284152][358470] = new Datum(6462721285409783950, 4, 902535584);
-      data[277544][358470] = new Datum(5026831778825708639, 4, 902535678);
-      data[269335][358470] = new Datum(2971770452830915701, 4, 902448648);
-      data[267252][358470] = new Datum(7441510589944616318, 4, 902448620);
-      data[264510][358470] = new Datum(8410067891696867813, 4, 902448650);
-      data[260924][358470] = new Datum(4919986680879759016, 4, 902448838);
-      data[258375][358470] = new Datum(5851055062358757678, 4, 896451088);
-      data[252786][358470] = new Datum(1181179272206183222, 4, 896460247);
-      data[250756][358470] = new Datum(5457565769128401790, 4, 896460334);
-      data[249913][358470] = new Datum(2832266850408399266, 4, 896460324);
-      data[249740][358470] = new Datum(6996102492712095516, 4, 896460342);
-      data[248828][358470] = new Datum(1215334353744988752, 4, 896460268);
-      data[248139][358470] = new Datum(9140920440213320364, 4, 896460286);
-      data[246379][358470] = new Datum(7419870507570765883, 3, 866850779);
-      data[244371][358470] = new Datum(8176613815265754262, 3, 749886317);
-      data[243520][358470] = new Datum(3645040643832281528, 2, 704403859);
-      data[226087][358470] = new Datum(0, 0, 0);
-      data[224995][358470] = new Datum(0, 0, 0);
-      data[224531][358470] = new Datum(0, 0, 0);
-      data[223249][358470] = new Datum(0, 0, 0);
-      data[222477][358470] = new Datum(0, 0, 0);
-      data[221394][358470] = new Datum(0, 0, 0);
-      data[220996][358470] = new Datum(0, 0, 0);
-      data[220675][358470] = new Datum(0, 0, 0);
-      data[220625][358470] = new Datum(0, 0, 0);
-      data[220480][358470] = new Datum(0, 0, 0);
+      data[220996] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 3475103749484918333,  2,   48912080, Package.Main),
+        new SteamManifest(257510, 257515, 0415067456888111848, 27, 5439377389, Package.Main),
+        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
+        new SteamManifest(257510, 257519, 4906101680219337427,  1,    1858219, Package.Main),
+        new SteamManifest(257510, 322022, 7673940384630485679,  3,  211726262, Package.Prototype)
+      };
 
-      data[440323][322022] = new Datum(8229910699963260352, 2, 201589569);
-      data[429074][322022] = new Datum(6956365166520441230, 2, 201571015);
-      data[426014][322022] = new Datum(1538185595447097219, 2, 201570963);
-      data[424910][322022] = new Datum(1251221992794837269, 2, 201570650);
-      data[326589][322022] = new Datum(1999687630096794293, 3, 191280306);
-      data[301136][322022] = new Datum(2866879691166241287, 3, 191280316);
-      data[300763][322022] = new Datum(1944742430107480164, 3, 191280316);
-      data[293384][322022] = new Datum(6864442709661062902, 3, 191280316);
-      data[291145][322022] = new Datum(0330496884825252439, 3, 191280317);
-      data[284152][322022] = new Datum(6922743269332565255, 3, 191280316);
-      data[277544][322022] = new Datum(4959862740532303621, 3, 191280317);
-      data[269335][322022] = new Datum(2804553596758319623, 3, 191280313);
-      data[267252][322022] = new Datum(3417810446044054571, 3, 191280318);
-      data[264510][322022] = new Datum(5194706371718824589, 3, 191280314);
-      data[260924][322022] = new Datum(7503933396680891180, 3, 191280306);
-      data[258375][322022] = new Datum(9214799288230159850, 3, 191280304);
-      data[252786][322022] = new Datum(6635364740942276299, 3, 191084684);
-      data[250756][322022] = new Datum(6332807582508063459, 3, 191084684);
-      data[249913][322022] = new Datum(1518316276430466929, 3, 191084684);
-      data[249740][322022] = new Datum(5134711953944719494, 3, 191084684);
-      data[248828][322022] = new Datum(6408748820177783708, 3, 191084683);
-      data[248139][322022] = new Datum(5515868016021140366, 3, 191084683);
-      data[246379][322022] = new Datum(4423801769448698176, 2, 191045699);
-      data[244371][322022] = new Datum(0570457731767330233, 2, 191173592);
-      data[243520][322022] = new Datum(1221230661228297401, 4, 291798721);
-      data[226087][322022] = new Datum(7180495594989737482, 4, 275966134);
-      data[224995][322022] = new Datum(6536174967355028889, 3, 243487857);
-      data[224531][322022] = new Datum(7516537008051594086, 3, 243488546);
-      data[223249][322022] = new Datum(3867407920981508845, 3, 225475676);
-      data[222477][322022] = new Datum(8917339509592123029, 3, 225475410);
-      data[221394][322022] = new Datum(6888774931510513164, 3, 218106434);
-      data[220996][322022] = new Datum(7673940384630485679, 3, 211726262);
-      data[220675][322022] = new Datum(4383443687812477256, 3, 206909511);
-      data[220625][322022] = new Datum(8183524469048336858, 3, 206907989);
-      data[220480][322022] = new Datum(2824340380872620137, 3, 172228256);
+      data[221394] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 1222567553988779631,  2,   48947920, Package.Main),
+        new SteamManifest(257510, 257515, 7204783264154690101, 27, 5842288583, Package.Main),
+        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
+        new SteamManifest(257510, 257519, 6019585236142413402,  1,    1981411, Package.Main),
+        new SteamManifest(257510, 322022, 6888774931510513164,  3,  218106434, Package.Prototype)
+      };
+
+      data[222477] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 0918811395787437543,  2,   49005264, Package.Main),
+        new SteamManifest(257510, 257515, 6267514976170907571, 27, 6094446568, Package.Main),
+        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
+        new SteamManifest(257510, 257519, 6671071736059004158,  1,    2059976, Package.Main),
+        new SteamManifest(257510, 322022, 8917339509592123029,  3,  225475410, Package.Prototype)
+      };
+
+      data[223249] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 4657839721186080333,  2,   49014480, Package.Main),
+        new SteamManifest(257510, 257515, 8304752583573271963, 27, 6094446741, Package.Main),
+        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
+        new SteamManifest(257510, 257519, 7835318215284690246,  1,    2059976, Package.Main),
+        new SteamManifest(257510, 322022, 3867407920981508845,  3,  225475676, Package.Prototype)
+      };
+
+      data[224531] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 3207947001105705384,  2,   37991120, Package.Main),
+        new SteamManifest(257510, 257515, 5798939509479840711, 28, 6281382910, Package.Main),
+        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
+        new SteamManifest(257510, 257519, 3565289474630779855,  1,    2117568, Package.Main),
+        new SteamManifest(257510, 322022, 7516537008051594086,  3,  243488546, Package.Prototype)
+      };
+
+      data[224995] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 9130874505093356390,  2,   38000336, Package.Main),
+        new SteamManifest(257510, 257515, 4840744566182207229, 28, 6281389510, Package.Main),
+        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
+        new SteamManifest(257510, 257519, 0660166059336687264,  1,    2117568, Package.Main),
+        new SteamManifest(257510, 322022, 6536174967355028889,  3,  243487857, Package.Prototype)
+      };
+
+      data[226087] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 2501832898327740448,  2,   38003408, Package.Main),
+        new SteamManifest(257510, 257515, 3826319505876650203, 29, 6282258753, Package.Main),
+        new SteamManifest(257510, 257516, 1237958166729860756,  6,     117245, Package.Main),
+        new SteamManifest(257510, 257519, 5081265059426016345,  1,    2117916, Package.Main),
+        new SteamManifest(257510, 322022, 7180495594989737482,  4,  275966134, Package.Prototype)
+      };
+
+      data[243520] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 0486897345253495735,  2,   37835472, Package.Main),
+        new SteamManifest(257510, 257515, 0762065295327824568, 29, 6870004878, Package.Main),
+        new SteamManifest(257510, 257516, 7901792711762181252,  7,     218389, Package.Main),
+        new SteamManifest(257510, 257519, 2020897382852338977,  1,    2312159, Package.Main),
+        new SteamManifest(257510, 358470, 3645040643832281528,  2,  704403859, Package.Gehenna),
+        new SteamManifest(257510, 322022, 1221230661228297401,  4,  291798721, Package.Prototype)
+      };
+
+      data[244371] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 7689461949196252397,  2,   37835472, Package.Main),
+        new SteamManifest(257510, 257515, 8579671038386532826, 28, 6427365830, Package.Main),
+        new SteamManifest(257510, 257516, 7901792711762181252,  7,     218389, Package.Main),
+        new SteamManifest(257510, 257519, 2675083093007158979,  1,    2175966, Package.Main),
+        new SteamManifest(257510, 358470, 8176613815265754262,  3,  749886317, Package.Gehenna),
+        new SteamManifest(257510, 322022, 0570457731767330233,  2,  191173592, Package.Prototype)
+      };
+
+      data[246379] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 7720637873729107634,  2,   37919440, Package.Main),
+        new SteamManifest(257510, 257515, 4896296030980495433, 29, 6546725617, Package.Main),
+        new SteamManifest(257510, 257516, 0537534056471328674,  2,     208576, Package.Main),
+        new SteamManifest(257510, 257519, 7776793304385903116,  1,    2213167, Package.Main),
+        new SteamManifest(257510, 358470, 7419870507570765883,  3,  866850779, Package.Gehenna),
+        new SteamManifest(257510, 322022, 4423801769448698176,  2,  191045699, Package.Prototype)
+      };
+
+      data[248139] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 1500898004646373285,  2,   37932240, Package.Main),
+        new SteamManifest(257510, 257515, 8022908710052117236, 30, 6589267934, Package.Main),
+        new SteamManifest(257510, 257516, 0537534056471328674,  2,     208576, Package.Main),
+        new SteamManifest(257510, 257519, 4793167457039384090,  1,    2226235, Package.Main),
+        new SteamManifest(257510, 358470, 9140920440213320364,  4,  896460286, Package.Gehenna),
+        new SteamManifest(257510, 322022, 5515868016021140366,  3,  191084683, Package.Prototype)
+      };
+
+      data[248828] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 4259291835568024105,  2,   37933264, Package.Main),
+        new SteamManifest(257510, 257515, 5103279241419561908, 30, 6589271132, Package.Main),
+        new SteamManifest(257510, 257516, 0537534056471328674,  2,     208576, Package.Main),
+        new SteamManifest(257510, 257519, 7130120369117951230,  1,    2226235, Package.Main),
+        new SteamManifest(257510, 358470, 1215334353744988752,  4,  896460268, Package.Gehenna),
+        new SteamManifest(257510, 322022, 6408748820177783708,  3,  191084683, Package.Prototype)
+      };
+
+      data[249740] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 2372465056935606724,  2,   37954768, Package.Main),
+        new SteamManifest(257510, 257515, 7774619190361198089, 29, 6590576873, Package.Main),
+        new SteamManifest(257510, 257516, 7546122753718189131,  2,     250448, Package.Main),
+        new SteamManifest(257510, 257519, 4648185825889483487,  1,    2226635, Package.Main),
+        new SteamManifest(257510, 358470, 6996102492712095516,  4,  896460342, Package.Gehenna),
+        new SteamManifest(257510, 322022, 5134711953944719494,  3,  191084684, Package.Prototype)
+      };
+
+      data[249913] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 0104511117861601608,  2,   37954256, Package.Main),
+        new SteamManifest(257510, 257515, 8145595254539830554, 29, 6590576890, Package.Main),
+        new SteamManifest(257510, 257516, 7546122753718189131,  2,     250448, Package.Main),
+        new SteamManifest(257510, 257519, 0264858112795519304,  1,    2226635, Package.Main),
+        new SteamManifest(257510, 358470, 2832266850408399266,  4,  896460324, Package.Gehenna),
+        new SteamManifest(257510, 322022, 1518316276430466929,  3,  191084684, Package.Prototype)
+      };
+
+      data[250756] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 1813793007507355582,  4,   84907936, Package.Main),
+        new SteamManifest(257510, 257515, 1726824934552610516, 29, 6604599929, Package.Main),
+        new SteamManifest(257510, 257516, 1646028800945546522,  4,     531616, Package.Main),
+        new SteamManifest(257510, 257519, 7529726526274038229,  1,    2230935, Package.Main),
+        new SteamManifest(257510, 358470, 5457565769128401790,  4,  896460334, Package.Gehenna),
+        new SteamManifest(257510, 322022, 6332807582508063459,  3,  191084684, Package.Prototype)
+      };
+
+      data[252786] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 4797710291018151156,  4,   84907936, Package.Main),
+        new SteamManifest(257510, 257515, 3411862904639819627, 29, 6604599937, Package.Main),
+        new SteamManifest(257510, 257516, 1646028800945546522,  4,     531616, Package.Main),
+        new SteamManifest(257510, 257519, 7754615816270172495,  1,    2230935, Package.Main),
+        new SteamManifest(257510, 358470, 1181179272206183222,  4,  896460247, Package.Gehenna),
+        new SteamManifest(257510, 322022, 6635364740942276299,  3,  191084684, Package.Prototype)
+      };
+
+      data[258375] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 0291313986193809433,  4,   84569504, Package.Main),
+        new SteamManifest(257510, 257515, 6044225467093048211, 29, 6667251114, Package.Main),
+        new SteamManifest(257510, 257516, 1646028800945546522,  4,     531616, Package.Main),
+        new SteamManifest(257510, 257519, 1808951156598981957,  1,    2250567, Package.Main),
+        new SteamManifest(257510, 358470, 5851055062358757678,  4,  896451088, Package.Gehenna),
+        new SteamManifest(257510, 322022, 9214799288230159850,  3,  191280304, Package.Prototype)
+      };
+
+      data[260924] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 0499590387152058814,  4,   86096800, Package.Main),
+        new SteamManifest(257510, 257515, 8206832965751498451, 29, 6667399585, Package.Main),
+        new SteamManifest(257510, 257516, 1646028800945546522,  4,     531616, Package.Main),
+        new SteamManifest(257510, 257519, 3398982331085565137,  1,    2250607, Package.Main),
+        new SteamManifest(257510, 358470, 4919986680879759016,  4,  902448838, Package.Gehenna),
+        new SteamManifest(257510, 322022, 7503933396680891180,  3,  191280306, Package.Prototype)
+      };
+
+      data[264510] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 4661937614683834332,  4,   86476576, Package.Main),
+        new SteamManifest(257510, 257515, 7995925049155399775, 29, 6677789906, Package.Main),
+        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
+        new SteamManifest(257510, 257519, 2063011968231605882,  1,    2253792, Package.Main),
+        new SteamManifest(257510, 358470, 8410067891696867813,  4,  902448650, Package.Gehenna),
+        new SteamManifest(257510, 322022, 5194706371718824589,  3,  191280314, Package.Prototype)
+      };
+
+      data[267252] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 0914480456153849155,  4,   86718752, Package.Main),
+        new SteamManifest(257510, 257515, 8897416572811879523, 29, 6704813319, Package.Main),
+        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
+        new SteamManifest(257510, 257519, 3339621383432167258,  1,    2262052, Package.Main),
+        new SteamManifest(257510, 358470, 7441510589944616318,  4,  902448620, Package.Gehenna),
+        new SteamManifest(257510, 322022, 3417810446044054571,  3,  191280318, Package.Prototype)
+      };
+
+      data[269335] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 4361546767985939876,  4,   87218976, Package.Main),
+        new SteamManifest(257510, 257515, 2778697671525586970, 29, 6704324599, Package.Main),
+        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
+        new SteamManifest(257510, 257519, 3429893718454775303,  1,    2261892, Package.Main),
+        new SteamManifest(257510, 358470, 2971770452830915701,  4,  902448648, Package.Gehenna),
+        new SteamManifest(257510, 322022, 2804553596758319623,  3,  191280313, Package.Prototype)
+      };
+
+      data[277544] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 4438368920362581908,  4,   87489312, Package.Main),
+        new SteamManifest(257510, 257515, 8527295741256308631, 29, 6701407239, Package.Main),
+        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
+        new SteamManifest(257510, 257519, 8707002697175431137,  1,    2261012, Package.Main),
+        new SteamManifest(257510, 358470, 5026831778825708639,  4,  902535678, Package.Gehenna),
+        new SteamManifest(257510, 322022, 4959862740532303621,  3,  191280317, Package.Prototype)
+      };
+
+      data[284152] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 2310534095082994736,  4,   87675168, Package.Main),
+        new SteamManifest(257510, 257515, 6023749242906446787, 29, 6701585582, Package.Main),
+        new SteamManifest(257510, 257516, 0827084533033961837,  6,     8172400, Package.Main),
+        new SteamManifest(257510, 257519, 3309514767764105231,  1,    2261052, Package.Main),
+        new SteamManifest(257510, 358470, 6462721285409783950,  4,  902535584, Package.Gehenna),
+        new SteamManifest(257510, 322022, 6922743269332565255,  3,  191280316, Package.Prototype)
+      };
+
+      data[291145] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 2517236650746590986,  4,   87096608, Package.Main),
+        new SteamManifest(257510, 257515, 5170392634591662639, 29, 6726169973, Package.Main),
+        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
+        new SteamManifest(257510, 257519, 5158478294883956711,  1,    2268552, Package.Main),
+        new SteamManifest(257510, 358470, 3878145609496862471,  4,  902535704, Package.Gehenna),
+        new SteamManifest(257510, 322022, 0330496884825252439,  3,  191280317, Package.Prototype)
+      };
+
+      data[293384] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 7465431023497269772,  4,   87130912, Package.Main),
+        new SteamManifest(257510, 257515, 3921528168366102418, 29, 6701195630, Package.Main),
+        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
+        new SteamManifest(257510, 257519, 2400271216751877709,  1,    2260932, Package.Main),
+        new SteamManifest(257510, 358470, 3689687611838010639,  4,  902535631, Package.Gehenna),
+        new SteamManifest(257510, 322022, 6864442709661062902,  3,  191280316, Package.Prototype)
+      };
+
+      data[300763] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 0236601650031060048,  4,   87206688, Package.Main),
+        new SteamManifest(257510, 257515, 3706310912589354532, 29, 6701203978, Package.Main),
+        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
+        new SteamManifest(257510, 257519, 8838046835968752341,  1,    2260932, Package.Main),
+        new SteamManifest(257510, 358470, 2608271957197798008,  4,  902535566, Package.Gehenna),
+        new SteamManifest(257510, 322022, 1944742430107480164,  3,  191280316, Package.Prototype)
+      };
+
+      data[301136] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 5351514903097441265,  4,   87213344, Package.Main),
+        new SteamManifest(257510, 257515, 0518026948382674055, 29, 6701203091, Package.Main),
+        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
+        new SteamManifest(257510, 257519, 3588926819998531108,  1,    2260932, Package.Main),
+        new SteamManifest(257510, 358470, 1599787433380595759,  4,  902535677, Package.Gehenna),
+        new SteamManifest(257510, 322022, 2866879691166241287,  3,  191280316, Package.Prototype)
+      };
+
+      data[326589] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 7222986970071829007,  4,   91624224, Package.Main),
+        new SteamManifest(257510, 257515, 3164152563056127398, 29, 6770687163, Package.Main),
+        new SteamManifest(257510, 257516, 0827084533033961837,  6,    8172400, Package.Main),
+        new SteamManifest(257510, 257519, 7686943783455980924,  1,    2282132, Package.Main),
+        new SteamManifest(257510, 358470, 5178136109328124898,  4,  902817535, Package.Gehenna),
+        new SteamManifest(257510, 322022, 1999687630096794293,  3,  191280306, Package.Prototype)
+      };
+
+      data[424910] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 4445925190137047197,  2,   66084984, Package.Main),
+        new SteamManifest(257510, 257515, 5833630477596020402, 49, 5634581190, Package.Main),
+        new SteamManifest(257510, 257516, 5450066894376160295, 11,   33548240, Package.Main),
+        new SteamManifest(257510, 358470, 0446988425271855249,  2,  777810959, Package.Gehenna),
+        new SteamManifest(257510, 322022, 1251221992794837269,  2,  201570650, Package.Prototype)
+      };
+
+      data[426014] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 3586505834137878681,  2,   66084976, Package.Main),
+        new SteamManifest(257510, 257515, 6301775319056368422, 50, 5663034799, Package.Main),
+        new SteamManifest(257510, 257516, 8705936455967316907, 11,   33548240, Package.Main),
+        new SteamManifest(257510, 358470, 3702226411907956172,  3,  786618977, Package.Gehenna),
+        new SteamManifest(257510, 322022, 1538185595447097219,  2,  201570963, Package.Prototype)
+      };
+
+      data[429074] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 8159846362257674313,  2,   66084984, Package.Main),
+        new SteamManifest(257510, 257515, 2713051319254128482, 50, 5663034511, Package.Main),
+        new SteamManifest(257510, 257516, 3680540037408603213, 11,   33548240, Package.Main),
+        new SteamManifest(257510, 358470, 6406142202705981356,  3,  786732859, Package.Gehenna),
+        new SteamManifest(257510, 322022, 6956365166520441230,  2,  201571015, Package.Prototype)
+      };
+
+      data[440323] = new List<SteamManifest> {
+        new SteamManifest(257510, 257511, 0799213806328220919,  2,   66117856, Package.Main),
+        new SteamManifest(257510, 257515, 3279814669572335644, 52, 5667320739, Package.Main),
+        new SteamManifest(257510, 257516, 7924825898116512954, 12,   34207184, Package.Main),
+        new SteamManifest(257510, 322022, 8229910699963260352,  2,  201589569, Package.Prototype),
+        new SteamManifest(257510, 358470, 0981576150363927305,  3,  883262060, Package.Gehenna)
+      };
+
+      System.Diagnostics.Debug.Assert(
+        data.Keys.All(ver => allVersions.Contains(ver)) && data.Keys.Count == allVersions.Count,
+        "Mismatch between versions in 'data' and 'allVersions'"
+      );
+
+      return data;
     }
   }
 }

--- a/Package.cs
+++ b/Package.cs
@@ -3,5 +3,6 @@
     Main,
     Gehenna,
     Prototype,
+    All
   }
 }

--- a/Package.cs
+++ b/Package.cs
@@ -2,7 +2,6 @@
   public enum Package {
     Main,
     Gehenna,
-    Prototype,
-    All
+    Prototype
   }
 }

--- a/SteamCommand.cs
+++ b/SteamCommand.cs
@@ -15,10 +15,12 @@ namespace TalosDownpatcher {
       Thread.Sleep(100); // Slight delay for steam to become foreground
     }
 
-    public static void DownloadDepot(int depot, long manifest) {
-      Logging.Log($"download_depot {GAME_ID} {depot} {manifest}");
-      if (manifest == 0) return; // 0 indicates "No such manifest", so we shouldn't attempt to download it.
-      sim.Keyboard.TextEntry($"download_depot {GAME_ID} {depot} {manifest}");
+    public static void DownloadManifest(SteamManifest manifest) {
+      if (manifest is null) throw new System.ArgumentNullException(nameof(manifest));
+
+      string cmd = $"download_depot {manifest.appId} {manifest.depotId} {manifest.manifestId}";
+      Logging.Log(cmd);
+      sim.Keyboard.TextEntry(cmd);
       sim.Keyboard.KeyPress(VirtualKeyCode.RETURN);
     }
 

--- a/SteamCommand.cs
+++ b/SteamCommand.cs
@@ -16,7 +16,9 @@ namespace TalosDownpatcher {
     }
 
     public static void DownloadManifest(SteamManifest manifest) {
-      if (manifest is null) throw new System.ArgumentNullException(nameof(manifest));
+      if (manifest == null || manifest.appId == 0 || manifest.depotId == 0 || manifest.manifestId == 0) {
+        return;
+      }
 
       string cmd = $"download_depot {manifest.appId} {manifest.depotId} {manifest.manifestId}";
       Logging.Log(cmd);


### PR DESCRIPTION
Paving the way to adding editor.

Changed `Datum` class to `SteamManifest`, which also holds app/depot id and package. Because of this switched the internal data format of `ManifestData` to a `Dictionary<int, List<SteamManifest>>`
Moved the initialization of the internal data into a private function `InitData()`, allowing the class to become static.
Removed the `[]` operator in favor of a function `GetManifestsForVersion()`, now that there's no longer a nested dict - package isn't an index in any sense.
